### PR TITLE
Fix node configuration and remove unnecessary flags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,3 @@ API_PORT=9052
 
 # System Resources
 JAVA_HEAP=2g
-
-# Generate your own API key hash using SHA-256
-# API_KEY_HASH=your_api_key_hash_here

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,12 @@ RUN apt-get update && \
 # Download Ergo jar
 RUN curl -L https://github.com/ergoplatform/ergo/releases/download/v${VERSION}/ergo-${VERSION}.jar -o ergo.jar
 
+# Create necessary directories
+RUN mkdir -p /opt/ergo/data
+
 COPY config/ergo.conf /opt/ergo/ergo.conf
 
 EXPOSE 9053 9052
 
-# Removed --nipopow flag since it's configured in ergo.conf
+# Run node with config file
 CMD ["java", "-Xmx2g", "-jar", "ergo.jar", "--config", "ergo.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,16 @@ RUN apt-get update && \
 # Download Ergo jar
 RUN curl -L https://github.com/ergoplatform/ergo/releases/download/v${VERSION}/ergo-${VERSION}.jar -o ergo.jar
 
-# Create necessary directories
+# Create directories and copy config
 RUN mkdir -p /opt/ergo/data
+COPY config /opt/ergo/config
 
-COPY config/ergo.conf /opt/ergo/ergo.conf
+WORKDIR /opt/ergo
+
+# Debug: List contents to verify config file
+RUN ls -la /opt/ergo/config
 
 EXPOSE 9053 9052
 
-# Run node with config file
-CMD ["java", "-Xmx2g", "-jar", "ergo.jar", "--config", "ergo.conf"]
+# Explicitly point to config file location
+CMD ["java", "-Xmx2g", "-jar", "ergo.jar", "--config", "/opt/ergo/config/ergo.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,13 @@ RUN apt-get update && \
 # Download Ergo jar
 RUN curl -L https://github.com/ergoplatform/ergo/releases/download/v${VERSION}/ergo-${VERSION}.jar -o ergo.jar
 
-# Create directories and copy config
-RUN mkdir -p /opt/ergo/data
-COPY config /opt/ergo/config
+# Create all necessary directories
+RUN mkdir -p /opt/ergo/data && \
+    mkdir -p /opt/ergo/data/wallet/keystore
 
-WORKDIR /opt/ergo
-
-# Debug: List contents to verify config file
-RUN ls -la /opt/ergo/config
+COPY config/ergo.conf /opt/ergo/config/ergo.conf
 
 EXPOSE 9053 9052
 
-# Explicitly point to config file location
+# Start the node
 CMD ["java", "-Xmx2g", "-jar", "ergo.jar", "--config", "/opt/ergo/config/ergo.conf"]

--- a/config/ergo.conf
+++ b/config/ergo.conf
@@ -1,33 +1,57 @@
 ergo {
-    directory = "/opt/ergo/data"
     node {
         mining = false
-        # Correct setting name for popow
+        # PoPoW settings
         popowBootstrap = true
-        utxo {
-           utxoBootstrap = true
-           storingUtxoSnapshots = 0
-        }
         # Genesis ID for mainnet
         genesisId = "b0244dfc267baca974a4caee06120321562784303a8a688976ae56170e4d175b"
-        
-        network {
-            magicBytes = [1, 0, 2, 4]
-            bindAddress = "0.0.0.0:9053"
-            nodeName = "shark-light-client"
-            knownPeers = [
-                "213.239.193.208:9053",
-                "159.65.11.55:9053",
-                "165.227.26.175:9053",
-                "159.89.116.15:9053"
-            ]
+
+        # UTXO settings
+        utxo {
+            utxoBootstrap = true
+            storingUtxoSnapshots = 0
         }
+
+        # Basic node info
+        name = "shark-light-client"
+        stateType = "utxo"
+
+        # Data directory path
+        dataDir = "/opt/ergo/data"
+
+        # Network specific settings
+        networkType = "mainnet"
+    }
+
+    chain {
+        # Mainnet magic bytes
+        magicBytes = [1, 0, 2, 4]
+    }
+
+    wallet {
+        testMnemonic = null
+        mnemonic = null
+        usePre1627KeyfileManager = false
+        secretStorage = null
     }
 }
 
 scorex {
+    network {
+        nodeName = "shark-light-client"
+        bindAddress = "0.0.0.0:9053"
+        knownPeers = [
+            "213.239.193.208:9053",
+            "159.65.11.55:9053",
+            "165.227.26.175:9053",
+            "159.89.116.15:9053"
+        ]
+        agentName = "shark"
+        magicBytes = [1, 0, 2, 4]
+    }
+
     restApi {
-        apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
         bindAddress = "0.0.0.0:9052"
+        apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
     }
 }

--- a/config/ergo.conf
+++ b/config/ergo.conf
@@ -1,4 +1,6 @@
 ergo {
+    directory = "/opt/ergo/data"
+    networkType = "mainnet"
     node {
         mining = false
         utxo {
@@ -9,11 +11,38 @@ ergo {
            nipopowBootstrap = true
            p2pNipopows = 2
         }
+        # Mainnet genesis ID
+        genesisId = "b0244dfc267baca974a4caee06120321562784303a8a688976ae56170e4d175b"
+        
+        network {
+            magicBytes = [1, 0, 2, 4]
+            bindAddress = "0.0.0.0:9053"
+            nodeName = "shark-light-client"
+            knownPeers = [
+                "213.239.193.208:9053",
+                "159.65.11.55:9053",
+                "165.227.26.175:9053",
+                "159.89.116.15:9053"
+            ]
+        }
     }
 }
 
 scorex {
     restApi {
+        # Default API key hash - you should change this
         apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
+        bindAddress = "0.0.0.0:9052"
+    }
+    network {
+        magicBytes = [1, 0, 2, 4]
+        bindAddress = "0.0.0.0:9053"
+        nodeName = "shark-light-client"
+        knownPeers = [
+            "213.239.193.208:9053",
+            "159.65.11.55:9053",
+            "165.227.26.175:9053",
+            "159.89.116.15:9053"
+        ]
     }
 }

--- a/config/ergo.conf
+++ b/config/ergo.conf
@@ -3,6 +3,8 @@ ergo {
     stateType = "digest"
     blocksToKeep = 1440
     mining = false
+    # Genesis ID for mainnet
+    genesisId = "b0244dfc267baca974a4caee06120321562784303a8a688976ae56170e4d175b"
     nipopow {
            nipopowBootstrap = true
            p2pNipopows = 2

--- a/config/ergo.conf
+++ b/config/ergo.conf
@@ -1,56 +1,18 @@
 ergo {
-    node {
-        mining = false
-        # PoPoW settings
-        popowBootstrap = true
-        # Genesis ID for mainnet
-        genesisId = "b0244dfc267baca974a4caee06120321562784303a8a688976ae56170e4d175b"
-
-        # UTXO settings
-        utxo {
-            utxoBootstrap = true
-            storingUtxoSnapshots = 0
-        }
-
-        # Basic node info
-        name = "shark-light-client"
-        stateType = "utxo"
-
-        # Data directory path
-        dataDir = "/opt/ergo/data"
-
-        # Network specific settings
-        networkType = "mainnet"
+  node {
+    stateType = "digest"
+    blocksToKeep = 1440
+    mining = false
+    nipopow {
+           nipopowBootstrap = true
+           p2pNipopows = 2
     }
-
-    chain {
-        # Mainnet magic bytes
-        magicBytes = [1, 0, 2, 4]
-    }
-
-    wallet {
-        secretStorage {
-            secretDir = "/opt/ergo/data/wallet/keystore"
-        }
-    }
+  }
 }
 
 scorex {
-    network {
-        nodeName = "shark-light-client"
-        bindAddress = "0.0.0.0:9053"
-        knownPeers = [
-            "213.239.193.208:9053",
-            "159.65.11.55:9053",
-            "165.227.26.175:9053",
-            "159.89.116.15:9053"
-        ]
-        agentName = "shark"
-        magicBytes = [1, 0, 2, 4]
-    }
-
-    restApi {
-        bindAddress = "0.0.0.0:9052"
-        apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
-    }
+  restApi {
+    # Hex-encoded Blake2b256 hash of an API key. Should be 64-chars long Base16 string.
+    apiKeyHash = "6ed54addddaf10fe8fcda330bd443a57914fbce38a9fa27248b07e361cc76a41"
+  }
 }

--- a/config/ergo.conf
+++ b/config/ergo.conf
@@ -29,10 +29,9 @@ ergo {
     }
 
     wallet {
-        testMnemonic = null
-        mnemonic = null
-        usePre1627KeyfileManager = false
-        secretStorage = null
+        secretStorage {
+            secretDir = "/opt/ergo/data/wallet/keystore"
+        }
     }
 }
 

--- a/config/ergo.conf
+++ b/config/ergo.conf
@@ -1,17 +1,14 @@
 ergo {
     directory = "/opt/ergo/data"
-    networkType = "mainnet"
     node {
         mining = false
+        # Correct setting name for popow
+        popowBootstrap = true
         utxo {
            utxoBootstrap = true
            storingUtxoSnapshots = 0
         }
-        nipopow {
-           nipopowBootstrap = true
-           p2pNipopows = 2
-        }
-        # Mainnet genesis ID
+        # Genesis ID for mainnet
         genesisId = "b0244dfc267baca974a4caee06120321562784303a8a688976ae56170e4d175b"
         
         network {
@@ -30,19 +27,7 @@ ergo {
 
 scorex {
     restApi {
-        # Default API key hash - you should change this
         apiKeyHash = "324dcf027dd4a30a932c441f365a25e86b173defa4b8e58948253471b81b72cf"
         bindAddress = "0.0.0.0:9052"
-    }
-    network {
-        magicBytes = [1, 0, 2, 4]
-        bindAddress = "0.0.0.0:9053"
-        nodeName = "shark-light-client"
-        knownPeers = [
-            "213.239.193.208:9053",
-            "159.65.11.55:9053",
-            "165.227.26.175:9053",
-            "159.89.116.15:9053"
-        ]
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - "${NODE_PORT:-9053}:9053"
       - "${API_PORT:-9052}:9052"
     volumes:
+      - ./config:/opt/ergo/config
       - ergo-data:/opt/ergo/data
     environment:
       - JAVA_OPTS=-Xmx${JAVA_HEAP:-2g}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       - "${NODE_PORT:-9053}:9053"
       - "${API_PORT:-9052}:9052"
     volumes:
-      - ./config:/opt/ergo/config
       - ergo-data:/opt/ergo/data
     environment:
       - JAVA_OPTS=-Xmx${JAVA_HEAP:-2g}
@@ -21,6 +20,7 @@ services:
 
 volumes:
   ergo-data:
+    driver: local
 
 networks:
   ergo-network:


### PR DESCRIPTION
This PR includes several important fixes:

1. Removed `--nipopow` flag from Dockerfile (now controlled via config)
2. Updated ergo.conf with correct light client settings
3. Simplified docker-compose configuration
4. Updated environment variables

Key changes:
- NiPoPoW configuration now properly set in ergo.conf
- UTXO bootstrap enabled for faster sync
- Removed unnecessary configuration options
- Added data directory creation in Dockerfile

Testing:
1. Container starts properly
2. Node connects and syncs with network
3. API endpoints accessible
4. Configuration validated